### PR TITLE
fix: align wrangler.toml project name with Pages deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "menagerie"
+name = "farcastle-proposals-frame"
 compatibility_date = "2024-07-29"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".next"


### PR DESCRIPTION
Updates the 'name' field in wrangler.toml to match the Cloudflare Pages project name. This ensures proper mapping between the build configuration and deployment target.