### PR TITLE
fix: remove env vars from wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,11 +2,3 @@ name = "farcastle-proposals-frame"
 compatibility_date = "2024-07-29"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"
-
-# Base environment variables (development)
-[vars]
-NEXT_PUBLIC_URL = "http://localhost:3000"
-
-# Production environment variables
-[env.production.vars]
-NEXT_PUBLIC_URL = "https://proposals.farcastle.net/"


### PR DESCRIPTION
- Remove environment variables from wrangler.toml
- Let Cloudflare dashboard manage all environment variables
- Fix deployment error with duplicate binding names