### PR TITLE
fix: remove environment variables from wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,10 +2,3 @@ name = "farcastle-proposals-frame"
 compatibility_date = "2024-07-29"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"
-
-[vars]
-NEXT_PUBLIC_URL = "http://localhost:3000"
-
-# Production environment variables
-[env.production.vars]
-NEXT_PUBLIC_URL = "https://proposals.farcastle.net/"


### PR DESCRIPTION
- Remove NEXT_PUBLIC_URL from [vars] and [env.production.vars]
- Environment variables will now be managed through:
  - Cloudflare dashboard for production
  - .env.local for development